### PR TITLE
Performance improvements by caching

### DIFF
--- a/layout/cycle_remover.go
+++ b/layout/cycle_remover.go
@@ -16,34 +16,32 @@ func NewSimpleCycleRemover() SimpleCycleRemover {
 	}
 }
 
-func getCycleDFS(g Graph, que []uint64) []uint64 {
+func getCycleDFS(neighbors map[uint64][]uint64, que []uint64) []uint64 {
 	if len(que) == 0 {
 		return que
 	}
 
 	p := que[len(que)-1]
-	for e := range g.Edges {
-		if e[0] == p {
-			// check if cycle
-			for i, t := range que {
-				if e[1] == t {
-					return que[i:]
-				}
+	for _, d := range neighbors[p] {
+		// check if cycle
+		for i, t := range que {
+			if d == t {
+				return que[i:]
 			}
+		}
 
-			// DFS deep call
-			if t := getCycleDFS(g, append(que, e[1])); len(t) > 0 {
-				return t
-			}
+		// DFS deep call
+		if t := getCycleDFS(neighbors, append(que, d)); len(t) > 0 {
+			return t
 		}
 	}
 
 	return nil
 }
 
-func getCycle(g Graph) []uint64 {
-	for _, root := range g.Roots() {
-		if t := getCycleDFS(g, []uint64{root}); len(t) > 0 {
+func getCycle(roots []uint64, neighbors map[uint64][]uint64) []uint64 {
+	for _, root := range roots {
+		if t := getCycleDFS(neighbors, []uint64{root}); len(t) > 0 {
 			return t
 		}
 	}
@@ -56,14 +54,31 @@ func reverseEdge(g Graph, e [2]uint64) {
 }
 
 func (s SimpleCycleRemover) RemoveCycles(g Graph) {
-	for cycle := getCycle(g); len(cycle) > 0; cycle = getCycle(g) {
+	neighbors := make(map[uint64][]uint64)
+	for e := range g.Edges {
+		neighbors[e[0]] = append(neighbors[e[0]], e[1])
+	}
+	for cycle := getCycle(g.Roots(), neighbors); len(cycle) > 0; cycle = getCycle(g.Roots(), neighbors) {
 		// pick edge randomly
 		i := rand.Intn(len(cycle) - 1)
 		e := [2]uint64{cycle[i], cycle[i+1]}
 
 		reverseEdge(g, e)
 		s.Reversed[e] = true
+
+		neighbors[e[0]] = deleteValue(neighbors[e[0]], e[1])
+		neighbors[e[1]] = append(neighbors[e[1]], e[0])
 	}
+}
+
+func deleteValue(slice []uint64, value uint64) []uint64 {
+	for i, n := range slice {
+		if n == value {
+			slice[i] = slice[len(slice)-1]
+			return slice[:len(slice)-1]
+		}
+	}
+	return slice
 }
 
 func (s SimpleCycleRemover) Restore(g Graph) {

--- a/layout/layers_layers_assigner.go
+++ b/layout/layers_layers_assigner.go
@@ -30,6 +30,10 @@ func maxNodeID(g Graph) uint64 {
 
 func assignLevels(g Graph) map[uint64][2]int {
 	nodeYX := make(map[uint64][2]int, len(g.Nodes))
+	neighbors := make(map[uint64][]uint64)
+	for e := range g.Edges {
+		neighbors[e[0]] = append(neighbors[e[0]], e[1])
+	}
 	for _, root := range g.Roots() {
 		nodeYX[root] = [2]int{0, 0}
 		for que := []uint64{root}; len(que) > 0; {
@@ -42,13 +46,11 @@ func assignLevels(g Graph) map[uint64][2]int {
 			}
 
 			// set max depth for each child
-			for e := range g.Edges {
-				if parent, child := e[0], e[1]; parent == p {
-					if l := nodeYX[parent][0] + 1; l > nodeYX[child][0] {
+			for _, child := range neighbors[p] {
+					if l := nodeYX[p][0] + 1; l > nodeYX[child][0] {
 						nodeYX[child] = [2]int{l, 0}
 					}
 					que = append(que, child)
-				}
 			}
 		}
 	}

--- a/layout/layers_ordering_assigner.go
+++ b/layout/layers_ordering_assigner.go
@@ -58,6 +58,9 @@ func (o WarfieldOrderingOptimizer) Optimize(g Graph, lg LayeredGraph) {
 			copyLayers(bestLayers, layers)
 		}
 		log.Printf("warfield ordering optimizer:\t epoch(%d)\t best(%d)\t current(%d)\n", t, bestN, N)
+		if N == 0 {
+			break
+		}
 	}
 
 	// store to graph
@@ -233,22 +236,18 @@ func (o SwitchAdjacentOrderingOptimizer) Optimize(segments map[[2]uint64]bool, l
 	for i := 0; i < (len(layers[y]) - 1); i++ {
 		j := i + 1
 
-		var ltop, lbottom []uint64
+		current := []uint64{layers[y][i], layers[y][j]}
+		swapped := []uint64{layers[y][j], layers[y][i]}
+		var currCrossings, swappedCrossings int
 		if downUp {
-			ltop = layers[y]
-			lbottom = layers[y+1]
+			currCrossings = numCrossingsBetweenLayers(segments, current, layers[y+1])
+			swappedCrossings = numCrossingsBetweenLayers(segments, swapped, layers[y+1])
 		} else {
-			ltop = layers[y-1]
-			lbottom = layers[y]
+			currCrossings = numCrossingsBetweenLayers(segments, layers[y-1], current)
+			swappedCrossings = numCrossingsBetweenLayers(segments, layers[y-1], swapped)
 		}
 
-		currCrossings := numCrossingsBetweenLayers(segments, ltop, lbottom)
-
-		// swap
-		layers[y][i], layers[y][j] = layers[y][j], layers[y][i]
-		swapCrossings := numCrossingsBetweenLayers(segments, ltop, lbottom)
-
-		if swapCrossings > currCrossings {
+		if swappedCrossings < currCrossings {
 			layers[y][i], layers[y][j] = layers[y][j], layers[y][i]
 		}
 	}


### PR DESCRIPTION
This MR makes 3 changes to improve the layer layouts:
- calls to `g.Layers()` are now stored in a variable to avoid computing it in loops (layer assigner, cycle remover, brandeskopf)
- neighbors are also cached to avoid parsing the whole segment list when trying to find neighbors of a single node (brandeskopf, cycle_remover)
- crossings comparisons for adjacent nodes in a layer are now computed only between these 2 adjacent nodes, since it is not useful to add crossing of unrelated nodes


Benchmarks


Running with No ordering assigner (0 epoch)
```go
	gl := layout.SugiyamaLayersStrategyGraphLayout{
		CycleRemover:   layout.NewSimpleCycleRemover(),
		LevelsAssigner: layout.NewLayeredGraph,
		OrderingAssigner: layout.WarfieldOrderingOptimizer{
			Epochs:                   0,
			LayerOrderingInitializer: layout.BFSOrderingInitializer{},
			LayerOrderingOptimizer: layout.CompositeLayerOrderingOptimizer{
				Optimizers: []layout.LayerOrderingOptimizer{
					// layout.WMedianOrderingOptimizer{},
					layout.SwitchAdjacentOrderingOptimizer{},
				},
			},
		}.Optimize,
		NodesHorizontalCoordinatesAssigner: layout.BrandesKopfLayersNodesHorizontalAssigner{
			Delta: 125,
		},
		NodesVerticalCoordinatesAssigner: layout.BasicNodesVerticalCoordinatesAssigner{
			MarginLayers:   125,
			FakeNodeHeight: 50,
		},
		EdgePathAssigner: layout.StraightEdgePathAssigner{}.UpdateGraphLayout,
	}
	gl.UpdateGraphLayout(g)

```
Example: tree with 5000 nodes:
[input.jsonl.json](https://github.com/user-attachments/files/17965677/input.jsonl.json)

Time for main version: 23 seconds
cycle remover:  322.1371ms
levels assigner:  328.6456ms
validate:  0s
ordering assigner:  2.5544ms
node horizontal coordinates:  22.2575877s
node vertical coordinates:  5.3355ms

Time for this version: 50ms seconds
cycle remover:  2.1821ms
levels assigner:  5.5674ms
validate:  536µs
ordering assigner:  4.5944ms
node horizontal coordinates:  22.4342ms
node vertical coordinates:  4.5977ms

Example: tree with 50000 nodes:
[input-50000.jsonl.json](https://github.com/user-attachments/files/17965746/input-50000.jsonl.json)

Time for main version: ?
cycle remover:  32.1171135s
levels assigner:  32.568738s
validate:  5.0201ms
ordering assigner:  46.0467ms
node horizonal coordinates: ? Didn't let it finish

Time for this version: 550ms
cycle remover:  37.5156ms
levels assigner:  48.2833ms
validate:  9.937ms
ordering assigner:  39.7217ms
node horizontal coordinates:  257.2831ms
node vertical coordinates:  52.993ms

